### PR TITLE
fixed webkit not found error

### DIFF
--- a/window.h
+++ b/window.h
@@ -2,7 +2,7 @@
 #define window_h
 
 #import <Cocoa/Cocoa.h>
-#import <WebKit/Webkit.h>
+#import <WebKit/WebKit.h>
 
 typedef struct Window__ {
   const char *ID;


### PR DESCRIPTION
This PR fixed the error that failed to find webkit framework on macOs 10.12.3 with Xcode 8.2.1 (8C1002)

```
# github.com/murlokswarm/mac
In file included from ../../../mac/window.go:4:
./window.h:5:9: fatal error: 'WebKit/Webkit.h' file not found
#import <WebKit/Webkit.h>
        ^
1 error generated.
```